### PR TITLE
Accommodate component slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,22 +293,26 @@ mix deps.compile slime --force
 
 ## HEEx Support
 
-To output HEEx instead of HTML, see [`phoenix_slime`](https://github.com/slime-lang/phoenix_slime). This will cause slime to emit "html aware" HEEx with two differences from conventional HTML:
+To output HEEx instead of HTML, see [`phoenix_slime`](https://github.com/slime-lang/phoenix_slime). This will cause slime to emit "html aware" HEEx with some differences from conventional HTML:
 
 - Attribute values will be wrapped in curley-braces (`{}`) instead of escaped EEx (`#{}`):
 
 - HTML Components will be prefixed with a dot. To render an HTML Component, prefix the component name with a colon (`:`).  This will tell slime to render these html tags with a dot-prefix (`.`).
+
+- Named component slots will be prefixed with a colon. To render these in Slime, prefix the slot name with a double colon (`::`).
 
 For example,
 
 ```slim
 :greet user=@current_user.name
   | Hello there!
+
+  ::footer Lovely day we're having, isn't it?
 ```
 would create the following output:
 
 ```
-<.greet user={@current_user.name}>Hello there!</.greet>
+<.greet user={@current_user.name}>Hello there!<:footer>Lovely day we're having, isn't it?</:footer></.greet>
 ```
 When using slime with Phoenix, the `phoenix_slime` package will call `precompile_heex/2` and pass the resulting valid HEEx to [`EEx`](https://hexdocs.pm/eex/EEx.html) with [`Phoenix.LiveView.HTMLEngine`](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.HTMLEngine.html#handle_text/3) as the `engine:` option.  This will produce the final html.
 

--- a/lib/slime/parser/transform.ex
+++ b/lib/slime/parser/transform.ex
@@ -214,6 +214,11 @@ defmodule Slime.Parser.Transform do
     %EExNode{content: to_string(content), output: true, safe?: safe == "="}
   end
 
+  def transform(:named_component_slot, ["::", name, _space, content], _index) do
+    {attributes, children, false} = content
+    %HEExNode{name: ":#{name}", attributes: attributes, children: children}
+  end
+
   def transform(:function_component, [":", name, _space, content], _index) do
     {attributes, children, false} = content
     # Match on brief function components, e.g. ".city" and explicit, e.g. "MyApp.city"

--- a/src/slime_parser.peg.eex
+++ b/src/slime_parser.peg.eex
@@ -3,7 +3,7 @@ document <- (space? crlf)* doctype? tags? eof;
 doctype <- space? 'doctype' space name:(!eol .)+ eol (space? crlf)*;
 
 tag <- comment / verbatim_text / tag_item;
-tag_item <- space? (embedded_engine / inline_html / code / function_component / slime_tag);
+tag_item <- space? (embedded_engine / inline_html / code / named_component_slot / function_component / slime_tag);
 
 tags <- (tag crlf*)+;
 nested_tags <- crlf+ indent tags dedent;
@@ -23,6 +23,8 @@ inline_tag <- ':' space? slime_tag;
 inline_text <- !eol text_block;
 
 dynamic_content <- '=' '='? space? (!eol .)+;
+
+named_component_slot <- '::' (slot_name) space? tag_attributes_and_content;
 
 function_component <- ':' (function_component_name) space? tag_attributes_and_content;
 
@@ -98,6 +100,7 @@ embedded_engine_lines <- indented_text_line (crlf indented_text_line)*;
 indented_text_line <- space? text_item*;
 
 tag_name <- [a-zA-Z0-9_-]+;
+slot_name <- [a-zA-Z0-9._-]+;
 function_component_name <- [a-zA-Z0-9._-]+;
 shortcut_value <- ([:/]? [a-zA-Z0-9_-])+;
 attribute_name <- [a-zA-Z0-9._@:-]+;

--- a/test/rendering/heex_test.exs
+++ b/test/rendering/heex_test.exs
@@ -56,4 +56,15 @@ defmodule FunctionComponentTest do
     heex = "<MyApp.module.city name={city_name}></MyApp.module.city>"
     assert precompile_heex(slime) == heex
   end
+
+  test "function components work with component slots" do
+    slime = ~s"""
+    :some_component
+      ::slot this is a component slot
+    """
+
+    heex = "<.some_component><:slot>this is a component slot</:slot></.some_component>"
+
+    assert precompile_heex(slime) == heex
+  end
 end


### PR DESCRIPTION
Phoenix LiveView components include the concept of slots,
HTML blocks that can be passed to the function
component and dynamically rendered. Named slots
are declared with a leading colon in standard HEEx,
but can be declared in Slime with a trailing double-colon.

This PR ensures the ability to declare and render component slots in HEEx-targeting templates.