### PR TITLE
Support for named component slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,22 +293,26 @@ mix deps.compile slime --force
 
 ## HEEx Support
 
-To output HEEx instead of HTML, see [`phoenix_slime`](https://github.com/slime-lang/phoenix_slime). This will cause slime to emit "html aware" HEEx with two differences from conventional HTML:
+To output HEEx instead of HTML, see [`phoenix_slime`](https://github.com/slime-lang/phoenix_slime). This will cause slime to emit "html aware" HEEx with some differences from conventional HTML:
 
 - Attribute values will be wrapped in curley-braces (`{}`) instead of escaped EEx (`#{}`):
 
 - HTML Components will be prefixed with a dot. To render an HTML Component, prefix the component name with a colon (`:`).  This will tell slime to render these html tags with a dot-prefix (`.`).
+
+- Named component slots will be prefixed with a colon. To render these in Slime, prefix the slot name with a double colon (`::`).
 
 For example,
 
 ```slim
 :greet user=@current_user.name
   | Hello there!
+
+  ::footer Lovely day we're having, isn't it?
 ```
 would create the following output:
 
 ```
-<.greet user={@current_user.name}>Hello there!</.greet>
+<.greet user={@current_user.name}>Hello there!<:footer>Lovely day we're having, isn't it?</:footer></.greet>
 ```
 When using slime with Phoenix, the `phoenix_slime` package will call `precompile_heex/2` and pass the resulting valid HEEx to [`EEx`](https://hexdocs.pm/eex/EEx.html) with [`Phoenix.LiveView.HTMLEngine`](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.HTMLEngine.html#handle_text/3) as the `engine:` option.  This will produce the final html.
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,9 +1,5 @@
-use Mix.Config
+import Config
 
-if Mix.env() == :test do
-  config :slime, :attr_list_delims, %{"[" => "]", "(" => ")"}
-
-  config :slime, :embedded_engines, %{
-    test_engine: RenderEmbeddedEngineTest.TestEngine
-  }
-end
+config = "#{config_env()}.exs"
+if File.exists?("#{__DIR__}/#{config}"),
+  do: import_config(config)

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,7 @@
+import Config
+
+config :slime, :attr_list_delims, %{"[" => "]", "(" => ")"}
+
+config :slime, :embedded_engines, %{
+  test_engine: RenderEmbeddedEngineTest.TestEngine
+}

--- a/lib/slime/parser/transform.ex
+++ b/lib/slime/parser/transform.ex
@@ -214,6 +214,11 @@ defmodule Slime.Parser.Transform do
     %EExNode{content: to_string(content), output: true, safe?: safe == "="}
   end
 
+  def transform(:named_component_slot, ["::", name, _space, content], _index) do
+    {attributes, children, false} = content
+    %HEExNode{name: ":#{name}", attributes: attributes, children: children}
+  end
+
   def transform(:function_component, [":", name, _space, content], _index) do
     {attributes, children, false} = content
     # Match on brief function components, e.g. ".city" and explicit, e.g. "MyApp.city"

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule Slime.Mixfile do
   def deps do
     [
       # packrat parser-generator for PEGs
-      {:neotoma, "~> 1.7"},
+      {:neotoma, "~> 1.7", manager: :rebar3, override: true},
       # Benchmarking tool
       {:benchfella, ">= 0.0.0", only: [:dev, :test], runtime: false},
       # Documentation

--- a/src/slime_parser.peg.eex
+++ b/src/slime_parser.peg.eex
@@ -3,7 +3,7 @@ document <- (space? crlf)* doctype? tags? eof;
 doctype <- space? 'doctype' space name:(!eol .)+ eol (space? crlf)*;
 
 tag <- comment / verbatim_text / tag_item;
-tag_item <- space? (embedded_engine / inline_html / code / function_component / slime_tag);
+tag_item <- space? (embedded_engine / inline_html / code / named_component_slot / function_component / slime_tag);
 
 tags <- (tag crlf*)+;
 nested_tags <- crlf+ indent tags dedent;
@@ -23,6 +23,8 @@ inline_tag <- ':' space? slime_tag;
 inline_text <- !eol text_block;
 
 dynamic_content <- '=' '='? space? (!eol .)+;
+
+named_component_slot <- '::' (slot_name) space? tag_attributes_and_content;
 
 function_component <- ':' (function_component_name) space? tag_attributes_and_content;
 
@@ -98,6 +100,7 @@ embedded_engine_lines <- indented_text_line (crlf indented_text_line)*;
 indented_text_line <- space? text_item*;
 
 tag_name <- [a-zA-Z0-9_-]+;
+slot_name <- [a-zA-Z0-9._-]+;
 function_component_name <- [a-zA-Z0-9._-]+;
 shortcut_value <- ([:/]? [a-zA-Z0-9_-])+;
 attribute_name <- [a-zA-Z0-9._@:-]+;

--- a/test/renderer_test.exs
+++ b/test/renderer_test.exs
@@ -119,9 +119,9 @@ defmodule RendererTest do
       example_windows = example_unix |> String.replace("\n", "\r\n")
 
       # Confirm that the unix version doesn't contain "\r"
-      assert not String.contains?(example_unix, "\r")
+      assert not example_unix =~ "\r"
       # Confirm that the windows bersion contains "\r"
-      assert String.contains?(example_windows, "\r")
+      assert example_windows =~ "\r"
 
       # Test precompilation on unix and windows, comparing to output
       assert Slime.Renderer.precompile(example_unix) == expected_precompiled_output

--- a/test/rendering/heex_test.exs
+++ b/test/rendering/heex_test.exs
@@ -56,4 +56,15 @@ defmodule FunctionComponentTest do
     heex = "<MyApp.module.city name={city_name}></MyApp.module.city>"
     assert precompile_heex(slime) == heex
   end
+
+  test "function components work with component slots" do
+    slime = ~s"""
+    :some_component
+      ::slot this is a component slot
+    """
+
+    heex = "<.some_component><:slot>this is a component slot</:slot></.some_component>"
+
+    assert precompile_heex(slime) == heex
+  end
 end

--- a/test/rendering/heex_test.exs
+++ b/test/rendering/heex_test.exs
@@ -52,8 +52,8 @@ defmodule FunctionComponentTest do
   end
 
   test "function components work with assigns when called with full module name" do
-    slime = ":MyApp.module.city name=city_name"
-    heex = "<MyApp.module.city name={city_name}></MyApp.module.city>"
+    slime = ":MyApp.Module.city name=city_name"
+    heex = "<MyApp.Module.city name={city_name}></MyApp.Module.city>"
     assert precompile_heex(slime) == heex
   end
 


### PR DESCRIPTION
Part of the `Phoenix.LiveView.Component` spec
(https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#module-named-slots),
inserted into a slime `.sheex` template by referencing them with a double colon.
E.g.,

```slim
main
  :special_form let=f for=@changeset
    ::header
      | This form is special because it has named slots
    ::footer
      | This named slot'll probably render closer to the end of the form
    label for="name" Name
    input#name placeholder="e.g., Konstantin Stanislavski"
    label for="email" Email address
    / ...
```